### PR TITLE
LwjglPlatform/build.gradle: Add natives for macOS arm64

### DIFF
--- a/LwjglPlatform/build.gradle
+++ b/LwjglPlatform/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation platform('org.lwjgl:lwjgl-bom:3.2.3')
     implementation "org.lwjgl:lwjgl-stb"
 
-    ['natives-linux', 'natives-windows', 'natives-macos'].each {
+    ['natives-linux', 'natives-windows', 'natives-macos', 'natives-macos-arm64'].each {
         implementation "org.lwjgl:lwjgl-stb::$it"
     }
 }


### PR DESCRIPTION
This (should) fix PaperVision on arm64 macOS.