### PR TITLE
build.gradle: Update `org.lwjgl:lwjgl-bom` to 3.3.4; imgui to 1.87.5

### DIFF
--- a/LwjglPlatform/build.gradle
+++ b/LwjglPlatform/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib"
     implementation "io.github.spair:imgui-java-app:$imgui_version"
 
-    implementation platform('org.lwjgl:lwjgl-bom:3.2.3')
+    implementation platform('org.lwjgl:lwjgl-bom:3.3.4')
     implementation "org.lwjgl:lwjgl-stb"
 
     ['natives-linux', 'natives-windows', 'natives-macos', 'natives-macos-arm64'].each {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         kotlin_version = "2.0.20"
         kotlinx_coroutines_version = "1.8.1"
         classgraph_version = "4.8.108"
-        imgui_version = "1.86.6"
+        imgui_version = "1.87.5"
 
         slf4j_version = "1.7.32"
         log4j_version = "2.17.1"


### PR DESCRIPTION
I have a hunch that 3.2.3 doesn't support macOS arm64, as it was released in 2019.